### PR TITLE
Suppress xtrace for set-env.sh [prom-api]

### DIFF
--- a/ai-machine-learning/prometheus-api-client/assets/setup.sh
+++ b/ai-machine-learning/prometheus-api-client/assets/setup.sh
@@ -1,0 +1,31 @@
+set +x
+curl -LO https://letsencrypt.org/certs/lets-encrypt-x3-cross-signed.pem > /dev/null 2>&1
+oc login -u developer -p developer --certificate-authority=lets-encrypt-x3-cross-signed.pem --insecure-skip-tls-verify=true > /dev/null 2>&1
+
+oc new-project myproject
+curl https://raw.githubusercontent.com/jupyter-on-openshift/jupyter-notebooks/2.4.0/image-streams/s2i-minimal-notebook.json | oc apply -f - -n myproject
+curl https://raw.githubusercontent.com/jupyter-on-openshift/jupyter-notebooks/2.4.0/templates/notebook-builder.json | sed -e 's/"Redirect"/"Allow"/' | oc apply -f - -n myproject
+curl https://raw.githubusercontent.com/jupyter-on-openshift/jupyter-notebooks/2.4.0/templates/notebook-deployer.json | sed -e 's/"Redirect"/"Allow"/' | oc apply -f - -n myproject
+curl https://raw.githubusercontent.com/jupyter-on-openshift/jupyter-notebooks/2.4.0/templates/notebook-quickstart.json | sed -e 's/"Redirect"/"Allow"/' | oc apply -f - -n myproject
+curl https://raw.githubusercontent.com/jupyter-on-openshift/jupyter-notebooks/2.4.0/templates/notebook-workspace.json | sed -e 's/"Redirect"/"Allow"/' | oc apply -f - -n myproject
+
+# set up Notebooks
+oc process notebook-builder -p GIT_REPOSITORY_URL=https://github.com/hemajv/prometheus-anomaly-detection-workshop.git -p CONTEXT_DIR=source/prometheus-api-client | oc apply -f - -n myproject
+oc process notebook-deployer -p NOTEBOOK_IMAGE=custom-notebook:latest -p NOTEBOOK_PASSWORD=secret | oc apply -f - -n myproject
+clear
+echo -e "Waiting for metrics data to be generated... (This might take a couple minutes)"
+until [ "$(oc get job prometheus-generate-data -o jsonpath='{.status.succeeded}' -n myproject &)" = "1" ];
+do
+  sleep 10
+done
+clear
+# set up Prometheus
+echo -e "Metric data generated, Setting up Prometheus"
+oc rollout latest prometheus-demo
+
+
+oc logs bc/custom-notebook -f
+clear
+echo -e "The environment should be ready in a few seconds"
+echo -e "The url to access the Jupyter Notebooks is: \n http://$(oc get route custom-notebook -o jsonpath='{.spec.host}' -n myproject) \n\n"
+echo -e "Prometheus Console is available at: \n http://$(oc get route prometheus-demo-route -o jsonpath='{.spec.host}' -n myproject)"

--- a/ai-machine-learning/prometheus-api-client/index.json
+++ b/ai-machine-learning/prometheus-api-client/index.json
@@ -38,7 +38,8 @@
         "assets": {
           "host01": [{"file": "deploy-prometheus.yaml", "target": "~/"},
                      {"file": "volumes.json", "target": "~/"},
-                     {"file": "generate-metrics.yaml", "target": "~/"}
+                     {"file": "generate-metrics.yaml", "target": "~/"},
+                     {"file": "setup.sh", "target": "~/"}
                     ]
         }
     }

--- a/ai-machine-learning/prometheus-api-client/set-env.sh
+++ b/ai-machine-learning/prometheus-api-client/set-env.sh
@@ -1,30 +1,4 @@
-launch.sh
-curl -LO https://letsencrypt.org/certs/lets-encrypt-x3-cross-signed.pem > /dev/null 2>&1
-oc login -u developer -p developer --certificate-authority=lets-encrypt-x3-cross-signed.pem --insecure-skip-tls-verify=true > /dev/null 2>&1
-
-oc new-project myproject
-curl https://raw.githubusercontent.com/jupyter-on-openshift/jupyter-notebooks/2.4.0/image-streams/s2i-minimal-notebook.json | oc apply -f - -n myproject
-curl https://raw.githubusercontent.com/jupyter-on-openshift/jupyter-notebooks/2.4.0/templates/notebook-builder.json | sed -e 's/"Redirect"/"Allow"/' | oc apply -f - -n myproject
-curl https://raw.githubusercontent.com/jupyter-on-openshift/jupyter-notebooks/2.4.0/templates/notebook-deployer.json | sed -e 's/"Redirect"/"Allow"/' | oc apply -f - -n myproject
-curl https://raw.githubusercontent.com/jupyter-on-openshift/jupyter-notebooks/2.4.0/templates/notebook-quickstart.json | sed -e 's/"Redirect"/"Allow"/' | oc apply -f - -n myproject
-curl https://raw.githubusercontent.com/jupyter-on-openshift/jupyter-notebooks/2.4.0/templates/notebook-workspace.json | sed -e 's/"Redirect"/"Allow"/' | oc apply -f - -n myproject
-
-# set up Notebooks
-oc process notebook-builder -p GIT_REPOSITORY_URL=https://github.com/hemajv/prometheus-anomaly-detection-workshop.git -p CONTEXT_DIR=source/prometheus-api-client | oc apply -f - -n myproject
-oc process notebook-deployer -p NOTEBOOK_IMAGE=custom-notebook:latest -p NOTEBOOK_PASSWORD=secret | oc apply -f - -n myproject
+while [ ! -f ~/setup.sh ]; do sleep 1; done # wait for the setup.sh file to exist
+chmod +x ~/setup.sh
 clear
-until [ "$(oc get job prometheus-generate-data -o jsonpath='{.status.succeeded}' -n myproject)" = "1" ];
-do
-  echo -e "Waiting for metrics data to be generated..."
-  sleep 10
-done
-# set up Prometheus
-echo -e "Metric data generated, Setting up Prometheus"
-oc rollout latest prometheus-demo
-
-
-oc logs bc/custom-notebook -f
-clear
-echo -e "The environment should be ready in a few seconds"
-echo -e "The url to access the Jupyter Notebooks is: \n http://$(oc get route custom-notebook -o jsonpath='{.spec.host}' -n myproject) \n\n"
-echo -e "Prometheus Console is available at: \n http://$(oc get route prometheus-demo-route -o jsonpath='{.spec.host}' -n myproject)"
+~/setup.sh


### PR DESCRIPTION
Move the setup script to assets so the xtrace (`set +x`) can be suppressed
Can be tested [here](https://www.katacoda.com/4n4nd/courses/ai-machine-learning/prometheus-api-client)

Closes #1 