### PR TITLE
[Prom-api]Add imagestream for pre-built notebook image

### DIFF
--- a/ai-machine-learning/prometheus-api-client/02-loading-the-notebook-templates.md
+++ b/ai-machine-learning/prometheus-api-client/02-loading-the-notebook-templates.md
@@ -10,7 +10,7 @@ http://prometheus-demo-route-myproject.[[HOST_SUBDOMAIN]]-80-[[KATACODA_HOST]].e
 
 The jupyter environment with the workshop notebooks is available here:
 
-http://custom-notebook-myproject.[[HOST_SUBDOMAIN]]-80-[[KATACODA_HOST]].environments.katacoda.com/
+http://prometheus-anomaly-detection-workshop-myproject.[[HOST_SUBDOMAIN]]-80-[[KATACODA_HOST]].environments.katacoda.com/
 
 You will need a password to access the environment.
 The password is `secret`{{copy}}

--- a/ai-machine-learning/prometheus-api-client/assets/notebook-imagestream.yaml
+++ b/ai-machine-learning/prometheus-api-client/assets/notebook-imagestream.yaml
@@ -1,0 +1,15 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: prometheus-anomaly-detection-workshop
+objects:
+  - apiVersion: v1
+    kind: ImageStream
+    metadata:
+      name: prometheus-anomaly-detection-workshop
+    spec:
+      tags:
+        - name: 'prometheus-api-client-katacoda'
+          from:
+            kind: DockerImage
+            name: 'quay.io/hveeradh/prometheus-anomaly-detection-workshop:prometheus-api-client-katacoda'

--- a/ai-machine-learning/prometheus-api-client/assets/setup.sh
+++ b/ai-machine-learning/prometheus-api-client/assets/setup.sh
@@ -3,15 +3,17 @@ curl -LO https://letsencrypt.org/certs/lets-encrypt-x3-cross-signed.pem > /dev/n
 oc login -u developer -p developer --certificate-authority=lets-encrypt-x3-cross-signed.pem --insecure-skip-tls-verify=true > /dev/null 2>&1
 
 oc new-project myproject
-curl https://raw.githubusercontent.com/jupyter-on-openshift/jupyter-notebooks/2.4.0/image-streams/s2i-minimal-notebook.json | oc apply -f - -n myproject
-curl https://raw.githubusercontent.com/jupyter-on-openshift/jupyter-notebooks/2.4.0/templates/notebook-builder.json | sed -e 's/"Redirect"/"Allow"/' | oc apply -f - -n myproject
+
+# set up dummy metrics in PVC
+oc process -f ./generate-metrics.yaml | oc apply -n myproject -f - --as system:admin
+# set up Prometheus
+oc process -f ./deploy-prometheus.yaml | oc apply -n myproject -f - --as system:admin
+
 curl https://raw.githubusercontent.com/jupyter-on-openshift/jupyter-notebooks/2.4.0/templates/notebook-deployer.json | sed -e 's/"Redirect"/"Allow"/' | oc apply -f - -n myproject
-curl https://raw.githubusercontent.com/jupyter-on-openshift/jupyter-notebooks/2.4.0/templates/notebook-quickstart.json | sed -e 's/"Redirect"/"Allow"/' | oc apply -f - -n myproject
-curl https://raw.githubusercontent.com/jupyter-on-openshift/jupyter-notebooks/2.4.0/templates/notebook-workspace.json | sed -e 's/"Redirect"/"Allow"/' | oc apply -f - -n myproject
 
 # set up Notebooks
-oc process notebook-builder -p GIT_REPOSITORY_URL=https://github.com/hemajv/prometheus-anomaly-detection-workshop.git -p CONTEXT_DIR=source/prometheus-api-client | oc apply -f - -n myproject
-oc process notebook-deployer -p NOTEBOOK_IMAGE=custom-notebook:latest -p NOTEBOOK_PASSWORD=secret | oc apply -f - -n myproject
+oc process -f ./notebook-imagestream.yaml | oc apply -f - -n myproject
+oc process notebook-deployer -p APPLICATION_NAME=prometheus-anomaly-detection-workshop -p NOTEBOOK_IMAGE=prometheus-anomaly-detection-workshop:prometheus-api-client-katacoda -p NOTEBOOK_PASSWORD=secret | oc apply -f - -n myproject
 clear
 echo -e "Waiting for metrics data to be generated... (This might take a couple minutes)"
 until [ "$(oc get job prometheus-generate-data -o jsonpath='{.status.succeeded}' -n myproject &)" = "1" ];
@@ -24,8 +26,8 @@ echo -e "Metric data generated, Setting up Prometheus"
 oc rollout latest prometheus-demo
 
 
-oc logs bc/custom-notebook -f
+oc logs bc/prometheus-anomaly-detection-workshop -f
 clear
 echo -e "The environment should be ready in a few seconds"
-echo -e "The url to access the Jupyter Notebooks is: \n http://$(oc get route custom-notebook -o jsonpath='{.spec.host}' -n myproject) \n\n"
+echo -e "The url to access the Jupyter Notebooks is: \n http://$(oc get route prometheus-anomaly-detection-workshop -o jsonpath='{.spec.host}' -n myproject) \n\n"
 echo -e "Prometheus Console is available at: \n http://$(oc get route prometheus-demo-route -o jsonpath='{.spec.host}' -n myproject)"

--- a/ai-machine-learning/prometheus-api-client/env-init.sh
+++ b/ai-machine-learning/prometheus-api-client/env-init.sh
@@ -2,9 +2,9 @@ ssh root@host01 'for i in {1..200}; do oc policy add-role-to-user system:image-p
 ssh root@host01 'oc adm policy add-cluster-role-to-group sudoer system:authenticated'
 ssh root@host01 "mkdir -p /data/pv-01 /data/pv-02 /data/pv-03 /data/pv-04 /data/pv-05 /data/pv-06 /data/pv-07 /data/pv-08 /data/pv-09 /data/pv-10"
 ssh root@host01 "chmod 0777 /data/pv-*; chcon -t svirt_sandbox_file_t /data/pv-*;"
-ssh root@host01 "oc create -f https://raw.githubusercontent.com/4n4nd/katacoda-scenarios/master/prometheus-api-client/assets/volumes.json --as system:admin"
+ssh root@host01 "while [ ! -f ~/volumes.json ]; do sleep 1; done; oc create -f ~/volumes.json --as system:admin;"
 # set up dummy metrics in PVC
-ssh root@host01 "oc process -f https://raw.githubusercontent.com/4n4nd/katacoda-scenarios/master/prometheus-api-client/assets/generate-metrics.yaml | oc apply -n myproject -f - --as system:admin"
+#ssh root@host01 "oc process -f https://raw.githubusercontent.com/4n4nd/katacoda-scenarios/master/prometheus-api-client/assets/generate-metrics.yaml | oc apply -n myproject -f - --as system:admin"
 
 # set up Prometheus
-ssh root@host01 "oc process -f https://raw.githubusercontent.com/4n4nd/katacoda-scenarios/master/prometheus-api-client/assets/deploy-prometheus.yaml | oc apply -n myproject -f - --as system:admin"
+# ssh root@host01 "oc process -f https://raw.githubusercontent.com/4n4nd/katacoda-scenarios/master/prometheus-api-client/assets/deploy-prometheus.yaml | oc apply -n myproject -f - --as system:admin"

--- a/ai-machine-learning/prometheus-api-client/index.json
+++ b/ai-machine-learning/prometheus-api-client/index.json
@@ -39,6 +39,7 @@
           "host01": [{"file": "deploy-prometheus.yaml", "target": "~/"},
                      {"file": "volumes.json", "target": "~/"},
                      {"file": "generate-metrics.yaml", "target": "~/"},
+                     {"file": "notebook-imagestream.yaml", "target": "~/"},
                      {"file": "setup.sh", "target": "~/"}
                     ]
         }


### PR DESCRIPTION
Use prebuilt notebook image from quay.io/hveeradh/prometheus-anomaly-detection-workshop:prometheus-api-client-katacoda
Instead of build the image in env

Can be tested [here](https://www.katacoda.com/4n4nd/courses/ai-machine-learning/prometheus-api-client)
Closes #4 